### PR TITLE
Create a `AttributeReportingConfigWithStatus` type

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -168,26 +168,21 @@ async def test_handle_message_read_report_conf(dev):
         3,  # dest EP
         b"\x18\x56\x09\x00\x00\x00\x00\x25\x1e\x00\x84\x03\x01\x02\x03\x04\x05\x06",  # message
     )
-    assert (
-        rsp is None
-    )  # Returns decoded msg when response is not pending, None otherwise
+    # Returns decoded msg when response is not pending, None otherwise
+    assert rsp is None
     assert req_mock.result.set_result.call_count == 1
-    assert (
-        req_mock.result.set_result.call_args[0][0][0]
-        == zigpy.zcl.foundation.Status.SUCCESS
-    )
-    assert len(req_mock.result.set_result.call_args[0][0][1]) == 1
-    cfg = req_mock.result.set_result.call_args[0][0][1][0]
-    assert isinstance(cfg, zigpy.zcl.foundation.AttributeReportingConfig)
-    assert cfg.direction == 0
-    assert cfg.attrid == 0
-    assert cfg.datatype == 0x25
-    assert cfg.min_interval == 30
-    assert cfg.max_interval == 900
-    assert cfg.reportable_change == 0x060504030201
+    cfg_sup1 = req_mock.result.set_result.call_args[0][0].attribute_configs[0]
+    assert isinstance(cfg_sup1, zigpy.zcl.foundation.AttributeReportingConfigWithStatus)
+    assert cfg_sup1.status == zigpy.zcl.foundation.Status.SUCCESS
+    assert cfg_sup1.config.direction == 0
+    assert cfg_sup1.config.attrid == 0
+    assert cfg_sup1.config.datatype == 0x25
+    assert cfg_sup1.config.min_interval == 30
+    assert cfg_sup1.config.max_interval == 900
+    assert cfg_sup1.config.reportable_change == 0x060504030201
 
     # Unsupported attributes
-    tsn2 = 0x53
+    tsn2 = 0x5B
     req_mock2 = MagicMock()
     dev._pending[tsn2] = req_mock2
     rsp2 = dev.handle_message(
@@ -197,11 +192,37 @@ async def test_handle_message_read_report_conf(dev):
         3,  # dest EP
         b"\x18\x5b\x09\x86\x00\x00\x00\x86\x00\x12\x00\x86\x00\x00\x04",  # message 3x("Unsupported attribute" response)
     )
+    # Returns decoded msg when response is not pending, None otherwise
+    assert rsp2 is None
+    cfg_unsup1, cfg_unsup2, cfg_unsup3 = req_mock2.result.set_result.call_args[0][
+        0
+    ].attribute_configs
     assert (
-        rsp2 is None
-    )  # Returns decoded msg when response is not pending, None otherwise
+        cfg_unsup1.status
+        == cfg_unsup2.status
+        == cfg_unsup3.status
+        == zigpy.zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE
+    )
+    assert cfg_unsup1.config.direction == 0x00 and cfg_unsup1.config.attrid == 0x0000
+    assert cfg_unsup2.config.direction == 0x00 and cfg_unsup2.config.attrid == 0x0012
+    assert cfg_unsup3.config.direction == 0x00 and cfg_unsup3.config.attrid == 0x0400
 
-    # TODO: Test case with more than one good report, one invalid
+    # One supported, one unsupported
+    tsn3 = 0x5C
+    req_mock3 = MagicMock()
+    dev._pending[tsn3] = req_mock3
+    rsp3 = dev.handle_message(
+        0x104,  # profile
+        0x702,  # cluster
+        3,  # source EP
+        3,  # dest EP
+        b"\x18\x5c\x09\x86\x00\x00\x00\x00\x00\x00\x00\x25\x1e\x00\x84\x03\x01\x02\x03\x04\x05\x06",
+    )
+    assert rsp3 is None
+    cfg_unsup4, cfg_sup2 = req_mock3.result.set_result.call_args[0][0].attribute_configs
+    assert cfg_unsup4.status == zigpy.zcl.foundation.Status.UNSUPPORTED_ATTRIBUTE
+    assert cfg_sup2.status == zigpy.zcl.foundation.Status.SUCCESS
+    assert cfg_sup2.serialize() == cfg_sup1.serialize()
 
 
 async def test_handle_message_reply(dev):

--- a/tests/test_zcl_foundation.py
+++ b/tests/test_zcl_foundation.py
@@ -86,6 +86,23 @@ def test_attribute_reporting_config_1():
     assert repr(arc)
 
 
+def test_attribute_reporting_config_only_dir_and_attrid():
+    arc = foundation.AttributeReportingConfig()
+    arc.direction = 0
+    arc.attrid = 99
+    ser = arc.serialize(_only_dir_and_attrid=True)
+
+    arc2, data = foundation.AttributeReportingConfig.deserialize(
+        ser, _only_dir_and_attrid=True
+    )
+    assert data == b""
+    assert arc2.direction == arc.direction
+    assert arc2.attrid == arc.attrid
+
+    assert repr(arc)
+    assert repr(arc) == repr(arc2)
+
+
 def test_typed_collection():
     tc = foundation.TypedCollection()
     tc.type = 0x20

--- a/zigpy/zcl/foundation.py
+++ b/zigpy/zcl/foundation.py
@@ -284,7 +284,7 @@ class AttributeReportingStatus(t.enum8):
 
 
 class AttributeReportingConfig:
-    def __init__(self, other=None):
+    def __init__(self, other=None) -> None:
         if isinstance(other, self.__class__):
             self.direction = other.direction
             self.attrid = other.attrid
@@ -296,9 +296,13 @@ class AttributeReportingConfig:
             self.max_interval = other.max_interval
             self.reportable_change = other.reportable_change
 
-    def serialize(self):
+    def serialize(self, *, _only_dir_and_attrid: bool = False) -> bytes:
         r = ReportingDirection(self.direction).serialize()
         r += t.uint16_t(self.attrid).serialize()
+
+        if _only_dir_and_attrid:
+            return r
+
         if self.direction == ReportingDirection.ReceiveReports:
             r += t.uint16_t(self.timeout).serialize()
         else:
@@ -312,10 +316,17 @@ class AttributeReportingConfig:
         return r
 
     @classmethod
-    def deserialize(cls, data):
+    def deserialize(
+        cls, data, *, _only_dir_and_attrid: bool = False
+    ) -> tuple[AttributeReportingConfig, bytes]:
         self = cls()
         self.direction, data = ReportingDirection.deserialize(data)
         self.attrid, data = t.uint16_t.deserialize(data)
+
+        # The report is only a direction and attribute
+        if _only_dir_and_attrid:
+            return self, data
+
         if self.direction == ReportingDirection.ReceiveReports:
             # Requesting things to be received by me
             self.timeout, data = t.uint16_t.deserialize(data)
@@ -330,14 +341,14 @@ class AttributeReportingConfig:
 
         return self, data
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         r = f"{self.__class__.__name__}("
         r += f"direction={self.direction}"
         r += f", attrid=0x{self.attrid:04X}"
 
         if self.direction == ReportingDirection.ReceiveReports:
             r += f", timeout={self.timeout}"
-        else:
+        elif hasattr(self, "datatype"):
             r += f", datatype={self.datatype}"
             r += f", min_interval={self.min_interval}"
             r += f", max_interval={self.max_interval}"
@@ -348,6 +359,32 @@ class AttributeReportingConfig:
         r += ")"
 
         return r
+
+
+class AttributeReportingConfigWithStatus(t.Struct):
+    status: Status
+    config: AttributeReportingConfig
+
+    @classmethod
+    def deserialize(
+        cls, data: bytes
+    ) -> tuple[AttributeReportingConfigWithStatus, bytes]:
+        status, data = Status.deserialize(data)
+
+        # FIXME: The reporting configuration will not include anything other than the
+        # direction and the attribute ID when the status is not successful. This
+        # information isn't a part of the attribute reporting config structure so we
+        # have to pass it in externally.
+        config, data = AttributeReportingConfig.deserialize(
+            data, _only_dir_and_attrid=(status != Status.SUCCESS)
+        )
+
+        return cls(status=status, config=config), data
+
+    def serialize(self) -> bytes:
+        return self.status.serialize() + self.config.serialize(
+            _only_dir_and_attrid=(self.status != Status.SUCCESS)
+        )
 
 
 class ConfigureReportingResponseRecord(t.Struct):
@@ -725,10 +762,7 @@ GENERAL_COMMANDS = COMMANDS = {
         is_reply=False,
     ),
     GeneralCommand.Read_Reporting_Configuration_rsp: ZCLCommandDef(
-        schema={
-            "status": Status,
-            "attribute_configs": t.List[AttributeReportingConfig],
-        },
+        schema={"attribute_configs": t.List[AttributeReportingConfigWithStatus]},
         is_reply=True,
     ),
     GeneralCommand.Report_Attributes: ZCLCommandDef(


### PR DESCRIPTION
I've added a new type called `AttributeReportingConfigWithStatus` and added a unit test that includes reporting configs with both successful and unsuccessful status codes.  The serialization/deserialization logic is unfortunately complex but it works.